### PR TITLE
Add Input System MVP gameplay scaffolding

### DIFF
--- a/Assets/Editor/ReadySceneBuilder.cs
+++ b/Assets/Editor/ReadySceneBuilder.cs
@@ -1,0 +1,312 @@
+using System;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+using EmpireOfHonor.Gameplay;
+using EmpireOfHonor.Input;
+using EmpireOfHonor.UI;
+
+namespace EmpireOfHonor.Editor
+{
+    /// <summary>
+    /// Provides a menu entry to build a ready-to-play scene with required components.
+    /// </summary>
+    public static class ReadySceneBuilder
+    {
+        private const string MenuPath = "Alaia Iva/Create READY Scene (Input System)";
+        private const string ScenePath = "Assets/ReadyScene_InputSystem.unity";
+
+        [MenuItem(MenuPath)]
+        public static void CreateReadyScene()
+        {
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            scene.name = "ReadyScene_InputSystem";
+
+            var ground = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            ground.name = "Ground";
+            ground.transform.localScale = Vector3.one * 5f;
+
+            TryAddNavMeshSurface(ground);
+
+            var light = new GameObject("Directional Light");
+            var lightComponent = light.AddComponent<Light>();
+            lightComponent.type = LightType.Directional;
+            light.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+
+            var inputAsset = AssetDatabase.LoadAssetAtPath<InputActionAsset>("Assets/Input/EmpireOfHonor.inputactions");
+            if (inputAsset == null)
+            {
+                Debug.LogError("Input action asset not found at Assets/Input/EmpireOfHonor.inputactions");
+                return;
+            }
+
+            var heroData = CreateHero(inputAsset);
+            var tacticalData = CreateTacticalCamera(inputAsset);
+            tacticalData.Camera.gameObject.SetActive(false);
+
+            var allies = CreateAllies(3);
+            CreateEnemies(3);
+
+            var manager = new GameObject("GameManager");
+            var switcher = manager.AddComponent<CameraSwitcher_Input>();
+            AssignCameraSwitcher(switcher, heroData.PlayerInput, heroData.TpsInput, heroData.Camera, tacticalData.Camera, tacticalData.Input);
+
+            var commandOverlay = manager.AddComponent<CommandOverlay_Input>();
+            AssignCommandOverlay(commandOverlay, inputAsset, tacticalData.Camera, allies);
+
+            var switcherSerialized = new SerializedObject(switcher);
+            switcherSerialized.FindProperty("commandOverlay").objectReferenceValue = commandOverlay;
+            switcherSerialized.FindProperty("switchAction").objectReferenceValue = heroData.SwitchReference;
+            switcherSerialized.ApplyModifiedPropertiesWithoutUndo();
+
+            CreateCanvas();
+
+            EditorSceneManager.SaveScene(scene, ScenePath);
+            AssetDatabase.Refresh();
+        }
+
+        private struct HeroData
+        {
+            public GameObject Hero;
+            public TPS_Input TpsInput;
+            public PlayerInput PlayerInput;
+            public Camera Camera;
+            public InputActionReference SwitchReference;
+        }
+
+        private struct TacticalData
+        {
+            public Camera Camera;
+            public Tactical_Input Input;
+        }
+
+        private static HeroData CreateHero(InputActionAsset inputAsset)
+        {
+            var hero = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            hero.name = "Hero";
+            hero.transform.position = new Vector3(0f, 1f, 0f);
+
+            var characterController = hero.AddComponent<CharacterController>();
+            characterController.height = 1.8f;
+            characterController.center = new Vector3(0f, 0.9f, 0f);
+
+            var health = hero.AddComponent<Health>();
+            SetSerializedEnum(new SerializedObject(health).FindProperty("team"), (int)Health.Team.Player);
+
+            hero.AddComponent<Weapon>();
+            var tpsInput = hero.AddComponent<TPS_Input>();
+
+            var cameraRoot = new GameObject("TPSCameraRoot");
+            cameraRoot.transform.SetParent(hero.transform, false);
+            cameraRoot.transform.localPosition = Vector3.zero;
+
+            var cameraPivot = new GameObject("TPSCameraPivot");
+            cameraPivot.transform.SetParent(cameraRoot.transform, false);
+            cameraPivot.transform.localPosition = new Vector3(0f, 1.6f, 0f);
+
+            var cameraObject = new GameObject("TPSCamera");
+            cameraObject.transform.SetParent(cameraPivot.transform, false);
+            cameraObject.transform.localPosition = new Vector3(0f, 0f, -4.5f);
+            cameraObject.transform.localRotation = Quaternion.identity;
+            var cameraComponent = cameraObject.AddComponent<Camera>();
+
+            var tpsSerialized = new SerializedObject(tpsInput);
+            tpsSerialized.FindProperty("characterController").objectReferenceValue = characterController;
+            tpsSerialized.FindProperty("cameraRoot").objectReferenceValue = cameraRoot.transform;
+            tpsSerialized.FindProperty("cameraPivot").objectReferenceValue = cameraPivot.transform;
+            tpsSerialized.FindProperty("moveAction").objectReferenceValue = CreateReference(inputAsset, "Player", "Move");
+            tpsSerialized.FindProperty("lookAction").objectReferenceValue = CreateReference(inputAsset, "Player", "Look");
+            tpsSerialized.FindProperty("jumpAction").objectReferenceValue = CreateReference(inputAsset, "Player", "Jump");
+            tpsSerialized.FindProperty("sprintAction").objectReferenceValue = CreateReference(inputAsset, "Player", "Sprint");
+            tpsSerialized.FindProperty("attackAction").objectReferenceValue = CreateReference(inputAsset, "Player", "Attack");
+            tpsSerialized.ApplyModifiedPropertiesWithoutUndo();
+
+            var playerInput = hero.AddComponent<PlayerInput>();
+            playerInput.actions = inputAsset;
+            playerInput.defaultActionMap = "Player";
+
+            var switchReference = CreateReference(inputAsset, "Player", "SwitchCamera");
+
+            return new HeroData
+            {
+                Hero = hero,
+                TpsInput = tpsInput,
+                PlayerInput = playerInput,
+                Camera = cameraComponent,
+                SwitchReference = switchReference
+            };
+        }
+
+        private static TacticalData CreateTacticalCamera(InputActionAsset inputAsset)
+        {
+            var tactical = new GameObject("TacticalCamera");
+            tactical.transform.position = new Vector3(0f, 20f, -10f);
+            tactical.transform.rotation = Quaternion.Euler(60f, 0f, 0f);
+            var camera = tactical.AddComponent<Camera>();
+
+            var tacticalInput = tactical.AddComponent<Tactical_Input>();
+            var serialized = new SerializedObject(tacticalInput);
+            serialized.FindProperty("panAction").objectReferenceValue = CreateReference(inputAsset, "Tactical", "Pan");
+            serialized.FindProperty("rotateLeftAction").objectReferenceValue = CreateReference(inputAsset, "Tactical", "RotateLeft");
+            serialized.FindProperty("rotateRightAction").objectReferenceValue = CreateReference(inputAsset, "Tactical", "RotateRight");
+            serialized.FindProperty("zoomAction").objectReferenceValue = CreateReference(inputAsset, "Tactical", "Zoom");
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+
+            tacticalInput.enabled = false;
+
+            return new TacticalData
+            {
+                Camera = camera,
+                Input = tacticalInput
+            };
+        }
+
+        private static void AssignCameraSwitcher(CameraSwitcher_Input switcher, PlayerInput playerInput, TPS_Input tpsInput, Camera tpsCamera, Camera tacticalCamera, Tactical_Input tacticalInput)
+        {
+            var serialized = new SerializedObject(switcher);
+            serialized.FindProperty("playerInput").objectReferenceValue = playerInput;
+            serialized.FindProperty("tpsCamera").objectReferenceValue = tpsCamera;
+            serialized.FindProperty("tacticalCamera").objectReferenceValue = tacticalCamera;
+            serialized.FindProperty("tpsController").objectReferenceValue = tpsInput;
+            serialized.FindProperty("tacticalController").objectReferenceValue = tacticalInput;
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        private static void AssignCommandOverlay(CommandOverlay_Input overlay, InputActionAsset asset, Camera tacticalCamera, GameObject[] allies)
+        {
+            var serialized = new SerializedObject(overlay);
+            serialized.FindProperty("tacticalCamera").objectReferenceValue = tacticalCamera;
+            serialized.FindProperty("commandAction").objectReferenceValue = CreateReference(asset, "Tactical", "Command");
+            serialized.FindProperty("holdAction").objectReferenceValue = CreateReference(asset, "Tactical", "Hold");
+            serialized.FindProperty("modifierAltAction").objectReferenceValue = CreateReference(asset, "Tactical", "ModifierAlt");
+            serialized.FindProperty("selectGroup1Action").objectReferenceValue = CreateReference(asset, "Tactical", "SelectGroup1");
+            serialized.FindProperty("selectGroup2Action").objectReferenceValue = CreateReference(asset, "Tactical", "SelectGroup2");
+            serialized.FindProperty("selectGroup3Action").objectReferenceValue = CreateReference(asset, "Tactical", "SelectGroup3");
+            serialized.FindProperty("selectGroup4Action").objectReferenceValue = CreateReference(asset, "Tactical", "SelectGroup4");
+
+            var groupsProp = serialized.FindProperty("groups");
+            groupsProp.arraySize = 4;
+            for (int i = 0; i < 4; i++)
+            {
+                var groupProp = groupsProp.GetArrayElementAtIndex(i);
+                groupProp.FindPropertyRelative("name").stringValue = $"Group {i + 1}";
+                var unitsProp = groupProp.FindPropertyRelative("units");
+                unitsProp.arraySize = 0;
+            }
+
+            for (int i = 0; i < allies.Length && i < 4; i++)
+            {
+                var unitsProp = groupsProp.GetArrayElementAtIndex(i).FindPropertyRelative("units");
+                unitsProp.arraySize = 1;
+                unitsProp.GetArrayElementAtIndex(0).objectReferenceValue = allies[i].GetComponent<UnitController>();
+            }
+
+            serialized.ApplyModifiedPropertiesWithoutUndo();
+        }
+
+        private static GameObject[] CreateAllies(int count)
+        {
+            var allies = new GameObject[count];
+            for (int i = 0; i < count; i++)
+            {
+                var ally = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+                ally.name = $"Ally_{i + 1}";
+                ally.transform.position = new Vector3(2f + i * 1.5f, 1f, 2f);
+
+                var agent = ally.AddComponent<NavMeshAgent>();
+                agent.speed = 3.5f;
+
+                var health = ally.AddComponent<Health>();
+                SetSerializedEnum(new SerializedObject(health).FindProperty("team"), (int)Health.Team.Ally);
+
+                ally.AddComponent<NavMeshAgentSnap>();
+                ally.AddComponent<Weapon>();
+                ally.AddComponent<UnitController>();
+
+                allies[i] = ally;
+            }
+
+            return allies;
+        }
+
+        private static void CreateEnemies(int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                var enemy = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+                enemy.name = $"Enemy_{i + 1}";
+                enemy.transform.position = new Vector3(-2f - i * 1.5f, 1f, -3f);
+
+                var agent = enemy.AddComponent<NavMeshAgent>();
+                agent.speed = 3.2f;
+
+                var health = enemy.AddComponent<Health>();
+                SetSerializedEnum(new SerializedObject(health).FindProperty("team"), (int)Health.Team.Enemy);
+
+                enemy.AddComponent<NavMeshAgentSnap>();
+                enemy.AddComponent<Weapon>();
+                enemy.AddComponent<SimpleEnemyAI>();
+            }
+        }
+
+        private static void CreateCanvas()
+        {
+            var canvasObject = new GameObject("UI Canvas");
+            var canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasObject.AddComponent<CanvasScaler>();
+            canvasObject.AddComponent<GraphicRaycaster>();
+
+            var textObject = new GameObject("Controls Text");
+            textObject.transform.SetParent(canvasObject.transform, false);
+            var rect = textObject.AddComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0f, 1f);
+            rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
+            rect.anchoredPosition = new Vector2(20f, -20f);
+            rect.sizeDelta = new Vector2(480f, 300f);
+
+            var text = textObject.AddComponent<Text>();
+            text.fontSize = 18;
+            text.color = Color.white;
+
+            textObject.AddComponent<SimpleUI>();
+        }
+
+        private static void TryAddNavMeshSurface(GameObject ground)
+        {
+#if UNITY_AINAVIGATION
+            var surface = ground.AddComponent<Unity.AI.Navigation.NavMeshSurface>();
+            surface.useGeometry = Unity.AI.Navigation.NavMeshCollectGeometry.RenderMeshes;
+            surface.BuildNavMesh();
+#else
+            var surfaceType = Type.GetType("Unity.AI.Navigation.NavMeshSurface, Unity.AI.Navigation");
+            if (surfaceType != null)
+            {
+                var surface = ground.AddComponent(surfaceType) as Component;
+                surfaceType.GetMethod("BuildNavMesh")?.Invoke(surface, null);
+            }
+#endif
+        }
+
+        private static InputActionReference CreateReference(InputActionAsset asset, string mapName, string actionName)
+        {
+            var action = asset.FindAction($"{mapName}/{actionName}", throwIfNotFound: true);
+            return InputActionReference.Create(action);
+        }
+
+        private static void SetSerializedEnum(SerializedProperty property, int value)
+        {
+            if (property == null)
+            {
+                return;
+            }
+
+            property.enumValueIndex = value;
+            property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
+        }
+    }
+}

--- a/Assets/Input/EmpireOfHonor.inputactions
+++ b/Assets/Input/EmpireOfHonor.inputactions
@@ -1,0 +1,453 @@
+{
+    "name": "EmpireOfHonor",
+    "maps": [
+        {
+            "name": "Player",
+            "id": "15b4c403-9dbc-4c7b-9a1a-4efb84153ae5",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "58b8fd99-0dc5-4a52-955a-46c61928f969",
+                    "expectedControlType": "Vector2"
+                },
+                {
+                    "name": "Look",
+                    "type": "Value",
+                    "id": "2c0c0228-4588-4e01-9d97-157353a811d2",
+                    "expectedControlType": "Vector2"
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "4f90d0f7-3639-471f-8de7-53a1ae6f7a80",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "Sprint",
+                    "type": "Button",
+                    "id": "b152c1fc-792f-4e17-9324-d8f4f0d5b14f",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "Attack",
+                    "type": "Button",
+                    "id": "ae96b345-8034-41f9-9466-d8a9f2e8bde9",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "SwitchCamera",
+                    "type": "Button",
+                    "id": "d3ba8f73-2b2d-4a4d-b2a5-78b475c2a76f",
+                    "expectedControlType": "Button"
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "WASD",
+                    "id": "a05f351f-2d30-42ec-8be7-9039d2dbe7e4",
+                    "path": "2DVector",
+                    "action": "Move",
+                    "isComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "8cf1c9a9-a7ac-4d60-8036-ffb3595bf056",
+                    "path": "<Keyboard>/w",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "8c17d57d-6f51-4207-b35d-bc172f4ba83f",
+                    "path": "<Keyboard>/s",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "b6f44503-5bcc-4d59-942a-215329dbe83b",
+                    "path": "<Keyboard>/a",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "d83dfcc9-b06b-46ca-a738-c9e1a3fa2a47",
+                    "path": "<Keyboard>/d",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left Stick",
+                    "id": "1689b162-cc64-4047-acdd-2037ef42928f",
+                    "path": "2DVector",
+                    "action": "Move",
+                    "isComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "86832c3f-eb91-45c3-9ee5-0c37aaee34f3",
+                    "path": "<Gamepad>/leftStick/up",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "934c7f0b-7e77-4cf6-b64f-4f3ed8a10919",
+                    "path": "<Gamepad>/leftStick/down",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "83f31533-e24c-4933-b5fa-78e074ea26d4",
+                    "path": "<Gamepad>/leftStick/left",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "4f443b5d-8760-4fdd-9b24-108f22c14f20",
+                    "path": "<Gamepad>/leftStick/right",
+                    "action": "Move",
+                    "isPartOfComposite": true
+                },
+                {
+                    "id": "36bb3417-1f22-4d8f-8a67-3e883efb79a3",
+                    "path": "<Mouse>/delta",
+                    "action": "Look"
+                },
+                {
+                    "id": "c8e1ea0a-0bd3-4d20-9a31-c442db8ab9cb",
+                    "path": "<Gamepad>/rightStick",
+                    "action": "Look"
+                },
+                {
+                    "id": "fab2624b-bf1a-4a59-b03f-bd8df4fc029c",
+                    "path": "<Keyboard>/space",
+                    "action": "Jump"
+                },
+                {
+                    "id": "bc14716c-4e86-4eaa-b356-13d097820ae2",
+                    "path": "<Gamepad>/buttonSouth",
+                    "action": "Jump"
+                },
+                {
+                    "id": "894e0cbb-48a0-462f-a7a7-74d2914176f7",
+                    "path": "<Keyboard>/leftShift",
+                    "action": "Sprint"
+                },
+                {
+                    "id": "a4f69863-3484-4b0f-9abe-465f1cb6f4f0",
+                    "path": "<Gamepad>/leftStickPress",
+                    "action": "Sprint"
+                },
+                {
+                    "id": "5780e289-3c91-4df4-a802-821ce1b6b548",
+                    "path": "<Mouse>/leftButton",
+                    "action": "Attack"
+                },
+                {
+                    "id": "b12bc770-d9ae-4efa-8ebc-0dca7980da3f",
+                    "path": "<Gamepad>/rightTrigger",
+                    "action": "Attack"
+                },
+                {
+                    "id": "d74c83f2-542d-476d-94db-a701e2f2bb3f",
+                    "path": "<Keyboard>/c",
+                    "action": "SwitchCamera"
+                },
+                {
+                    "id": "ea6a3aba-6220-4653-9960-7b5d86945d05",
+                    "path": "<Gamepad>/select",
+                    "action": "SwitchCamera"
+                }
+            ]
+        },
+        {
+            "name": "Tactical",
+            "id": "23a75f96-0dcc-4abe-b9eb-386d5dab0b98",
+            "actions": [
+                {
+                    "name": "Pan",
+                    "type": "Value",
+                    "id": "84c89d01-44fb-4fde-8c40-19a3b4a2c491",
+                    "expectedControlType": "Vector2"
+                },
+                {
+                    "name": "RotateLeft",
+                    "type": "Button",
+                    "id": "127b9cc5-62dd-4d83-a3dd-1674d39884a5",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "RotateRight",
+                    "type": "Button",
+                    "id": "2d476a28-d3f9-4f9d-9598-c8578ca8b208",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "Zoom",
+                    "type": "Value",
+                    "id": "a30a9a5f-d673-4c41-8fb7-95cc004fe9cd",
+                    "expectedControlType": "Axis"
+                },
+                {
+                    "name": "Command",
+                    "type": "Button",
+                    "id": "eae4f49b-6a4d-441e-a1f3-8a64b5049b61",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "Hold",
+                    "type": "Button",
+                    "id": "2fb86e79-3d71-463d-aab5-0c754fe64182",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "ModifierAlt",
+                    "type": "Button",
+                    "id": "fbbd93f5-a8f0-4c21-a4f8-047d6ad1d4d4",
+                    "expectedControlType": "Button"
+                },
+                {
+                    "name": "SelectGroup1",
+                    "type": "Button",
+                    "id": "6e3acbb6-6d6f-46bb-b64c-6adc3cc478c0"
+                },
+                {
+                    "name": "SelectGroup2",
+                    "type": "Button",
+                    "id": "672af80a-4cf3-4f15-b0b6-020e216a4a5a"
+                },
+                {
+                    "name": "SelectGroup3",
+                    "type": "Button",
+                    "id": "8ac00700-93ae-4d0b-8120-898354c8a93b"
+                },
+                {
+                    "name": "SelectGroup4",
+                    "type": "Button",
+                    "id": "a2f57f5f-7278-4f0d-9ee4-1988f95d6421"
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "WASD",
+                    "id": "3480b372-b3cf-4d6f-aba1-a09f923c6dcf",
+                    "path": "2DVector",
+                    "action": "Pan",
+                    "isComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "2f015833-01b2-4785-8f3c-5015ee728d69",
+                    "path": "<Keyboard>/w",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "de21ae42-8569-4c1c-955c-b18c08375118",
+                    "path": "<Keyboard>/s",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "df20a117-4555-4655-a788-c8736c3a9f9a",
+                    "path": "<Keyboard>/a",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "80101e02-6f39-469d-9900-9607d19bc980",
+                    "path": "<Keyboard>/d",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left Stick",
+                    "id": "1affb269-e356-493e-a9fe-b2db98371f01",
+                    "path": "2DVector",
+                    "action": "Pan",
+                    "isComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "980b4d0c-8b15-4f7e-a747-a5c5d54260a4",
+                    "path": "<Gamepad>/leftStick/up",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "9edcd18e-ec89-4fb4-a635-66ff4b7ee87a",
+                    "path": "<Gamepad>/leftStick/down",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "170932cb-0f25-4c98-9091-a70a68223d73",
+                    "path": "<Gamepad>/leftStick/left",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "64ec6018-debc-4c8a-9cf0-6bdcd4f4a0f6",
+                    "path": "<Gamepad>/leftStick/right",
+                    "action": "Pan",
+                    "isPartOfComposite": true
+                },
+                {
+                    "id": "f1b1382d-383f-492b-868b-68ca04f3487d",
+                    "path": "<Keyboard>/q",
+                    "action": "RotateLeft"
+                },
+                {
+                    "id": "f1b54f0a-d8e7-4090-a1e0-0180a5ad8f3f",
+                    "path": "<Keyboard>/e",
+                    "action": "RotateRight"
+                },
+                {
+                    "id": "b7398c35-f719-442f-94b2-760f900949b4",
+                    "path": "<Gamepad>/leftShoulder",
+                    "action": "RotateLeft"
+                },
+                {
+                    "id": "9f6c346d-48fa-4449-bbe1-81b30b03bb69",
+                    "path": "<Gamepad>/rightShoulder",
+                    "action": "RotateRight"
+                },
+                {
+                    "id": "384cc711-4ec9-49e9-9b6b-28426e1eb510",
+                    "path": "<Mouse>/scroll/y",
+                    "action": "Zoom"
+                },
+                {
+                    "id": "265f695e-f687-4a7d-b9ff-9bb9a4a191fa",
+                    "path": "1DAxis",
+                    "action": "Zoom",
+                    "isComposite": true
+                },
+                {
+                    "name": "negative",
+                    "id": "2f4b3426-945e-4d2d-99a8-3fef8b626d4c",
+                    "path": "<Gamepad>/leftTrigger",
+                    "action": "Zoom",
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "a6db476e-181a-4a70-b316-b8e53bc8ded4",
+                    "path": "<Gamepad>/rightTrigger",
+                    "action": "Zoom",
+                    "isPartOfComposite": true
+                },
+                {
+                    "id": "577dfd4b-8557-4ccd-88c7-5bd7814ac36c",
+                    "path": "<Mouse>/leftButton",
+                    "action": "Command"
+                },
+                {
+                    "id": "a5af1782-23f4-47a8-92f7-cb9ee0ae0f41",
+                    "path": "<Gamepad>/buttonSouth",
+                    "action": "Command"
+                },
+                {
+                    "id": "c28adfaf-b413-4b56-b53a-23ad54161377",
+                    "path": "<Mouse>/rightButton",
+                    "action": "Hold"
+                },
+                {
+                    "id": "65dbc3f2-ac53-4071-91d7-1d324edcfaa4",
+                    "path": "<Gamepad>/buttonEast",
+                    "action": "Hold"
+                },
+                {
+                    "id": "e452edfa-2e0f-4e29-905d-2041518ec82c",
+                    "path": "<Keyboard>/leftAlt",
+                    "action": "ModifierAlt"
+                },
+                {
+                    "id": "87b14226-4d4a-443d-b72a-583dc01bcb67",
+                    "path": "<Gamepad>/leftShoulder",
+                    "action": "ModifierAlt"
+                },
+                {
+                    "id": "9d3adc76-4a5b-4ef5-b558-f2c814200f49",
+                    "path": "<Keyboard>/1",
+                    "action": "SelectGroup1"
+                },
+                {
+                    "id": "f28f3b47-587f-4963-bcc8-0f5a736c38c6",
+                    "path": "<Keyboard>/2",
+                    "action": "SelectGroup2"
+                },
+                {
+                    "id": "c8d4de36-f44f-45db-9534-1e09fae9e820",
+                    "path": "<Keyboard>/3",
+                    "action": "SelectGroup3"
+                },
+                {
+                    "id": "5d983d9a-0ca2-43fe-88fe-07b7405eaf06",
+                    "path": "<Keyboard>/4",
+                    "action": "SelectGroup4"
+                },
+                {
+                    "id": "111794fc-dabb-4664-843b-6c1a87c030cf",
+                    "path": "<Gamepad>/dpad/left",
+                    "action": "SelectGroup1"
+                },
+                {
+                    "id": "728d81cc-4ede-4a41-9dec-672844e7d1d1",
+                    "path": "<Gamepad>/dpad/right",
+                    "action": "SelectGroup2"
+                },
+                {
+                    "id": "ada69f30-2457-4c95-b4a4-596d8f0927ba",
+                    "path": "<Gamepad>/dpad/up",
+                    "action": "SelectGroup3"
+                },
+                {
+                    "id": "c7b65b75-dfc1-4d9b-b61a-b8961c5c70da",
+                    "path": "<Gamepad>/dpad/down",
+                    "action": "SelectGroup4"
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "KeyboardMouse",
+            "bindingGroup": "KeyboardMouse",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                },
+                {
+                    "devicePath": "<Mouse>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Gamepad",
+            "bindingGroup": "Gamepad",
+            "devices": [
+                {
+                    "devicePath": "<Gamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/Assets/Scripts/Gameplay/Health.cs
+++ b/Assets/Scripts/Gameplay/Health.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace EmpireOfHonor.Gameplay
+{
+    /// <summary>
+    /// Simple team-based health container with automatic registry management.
+    /// </summary>
+    public class Health : MonoBehaviour
+    {
+        public enum Team
+        {
+            Player,
+            Ally,
+            Enemy
+        }
+
+        private static readonly Dictionary<Team, List<Health>> Registry = new();
+
+        [SerializeField] private Team team = Team.Enemy;
+        [SerializeField] private float maxHealth = 100f;
+
+        private float currentHealth;
+
+        /// <summary>
+        /// Gets the team this entity belongs to.
+        /// </summary>
+        public Team TeamId => team;
+
+        /// <summary>
+        /// Gets the current health value.
+        /// </summary>
+        public float CurrentHealth => currentHealth;
+
+        private void OnEnable()
+        {
+            currentHealth = Mathf.Clamp(currentHealth <= 0f ? maxHealth : currentHealth, 0f, maxHealth);
+            if (!Registry.TryGetValue(team, out var list))
+            {
+                list = new List<Health>();
+                Registry.Add(team, list);
+            }
+
+            if (!list.Contains(this))
+            {
+                list.Add(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (Registry.TryGetValue(team, out var list))
+            {
+                list.Remove(this);
+            }
+        }
+
+        /// <summary>
+        /// Applies damage and disables the GameObject when health reaches zero.
+        /// </summary>
+        /// <param name="amount">Amount of health to remove.</param>
+        public void ApplyDamage(float amount)
+        {
+            if (currentHealth <= 0f)
+            {
+                return;
+            }
+
+            currentHealth = Mathf.Clamp(currentHealth - Mathf.Abs(amount), 0f, maxHealth);
+            if (currentHealth <= 0f)
+            {
+                gameObject.SetActive(false);
+            }
+        }
+
+        /// <summary>
+        /// Returns a copy of the list of health components registered for the given team.
+        /// </summary>
+        /// <param name="team">Team to query.</param>
+        public static List<Health> GetAllies(Team team)
+        {
+            if (!Registry.TryGetValue(team, out var list))
+            {
+                return new List<Health>();
+            }
+
+            return new List<Health>(list);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/NavMeshAgentSnap.cs
+++ b/Assets/Scripts/Gameplay/NavMeshAgentSnap.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace EmpireOfHonor.Gameplay
+{
+    /// <summary>
+    /// Snaps a NavMeshAgent to the closest position on the baked NavMesh on start.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class NavMeshAgentSnap : MonoBehaviour
+    {
+        [SerializeField] private float maxDistance = 5f;
+
+        private void Start()
+        {
+            var agent = GetComponent<NavMeshAgent>();
+            if (agent == null)
+            {
+                return;
+            }
+
+            if (NavMesh.SamplePosition(transform.position, out var hit, maxDistance, NavMesh.AllAreas))
+            {
+                agent.Warp(hit.position);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/SimpleEnemyAI.cs
+++ b/Assets/Scripts/Gameplay/SimpleEnemyAI.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace EmpireOfHonor.Gameplay
+{
+    /// <summary>
+    /// Minimal AI that chases the closest non-allied target and performs melee attacks.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    [RequireComponent(typeof(Weapon))]
+    [RequireComponent(typeof(Health))]
+    public class SimpleEnemyAI : MonoBehaviour
+    {
+        [SerializeField] private float repathInterval = 0.5f;
+        [SerializeField] private float rotationSpeed = 10f;
+
+        private NavMeshAgent agent;
+        private Weapon weapon;
+        private Health health;
+        private Health currentTarget;
+        private float repathTimer;
+
+        private void Awake()
+        {
+            agent = GetComponent<NavMeshAgent>();
+            weapon = GetComponent<Weapon>();
+            health = GetComponent<Health>();
+        }
+
+        private void Update()
+        {
+            if (!gameObject.activeInHierarchy || health.CurrentHealth <= 0f)
+            {
+                return;
+            }
+
+            repathTimer -= Time.deltaTime;
+            if (currentTarget == null || !currentTarget.gameObject.activeInHierarchy || currentTarget.CurrentHealth <= 0f || repathTimer <= 0f)
+            {
+                currentTarget = FindClosestTarget();
+                repathTimer = repathInterval;
+                if (currentTarget != null && agent.isOnNavMesh)
+                {
+                    agent.isStopped = false;
+                    agent.SetDestination(currentTarget.transform.position);
+                }
+            }
+
+            if (currentTarget == null)
+            {
+                if (agent.isOnNavMesh)
+                {
+                    agent.isStopped = true;
+                }
+
+                return;
+            }
+
+            var targetPosition = currentTarget.transform.position;
+            var distance = Vector3.Distance(transform.position, targetPosition);
+            if (agent.isOnNavMesh)
+            {
+                agent.SetDestination(targetPosition);
+                if (distance <= weapon.Range + 0.05f)
+                {
+                    agent.isStopped = true;
+                }
+                else
+                {
+                    agent.isStopped = false;
+                }
+            }
+
+            RotateTowards(targetPosition);
+            if (distance <= weapon.Range + 0.05f)
+            {
+                weapon.TryAttack();
+            }
+        }
+
+        private Health FindClosestTarget()
+        {
+            var allTargets = new List<Health>();
+            foreach (Health.Team team in Enum.GetValues(typeof(Health.Team)))
+            {
+                if (team == health.TeamId)
+                {
+                    continue;
+                }
+
+                allTargets.AddRange(Health.GetAllies(team));
+            }
+
+            var shortestDistance = float.MaxValue;
+            Health bestTarget = null;
+            foreach (var candidate in allTargets)
+            {
+                if (candidate == null || !candidate.gameObject.activeInHierarchy || candidate.CurrentHealth <= 0f)
+                {
+                    continue;
+                }
+
+                var distance = Vector3.Distance(transform.position, candidate.transform.position);
+                if (distance < shortestDistance)
+                {
+                    shortestDistance = distance;
+                    bestTarget = candidate;
+                }
+            }
+
+            return bestTarget;
+        }
+
+        private void RotateTowards(Vector3 targetPosition)
+        {
+            var direction = targetPosition - transform.position;
+            direction.y = 0f;
+            if (direction.sqrMagnitude < 0.001f)
+            {
+                return;
+            }
+
+            var desiredRotation = Quaternion.LookRotation(direction.normalized, Vector3.up);
+            transform.rotation = Quaternion.Slerp(transform.rotation, desiredRotation, rotationSpeed * Time.deltaTime);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/UnitController.cs
+++ b/Assets/Scripts/Gameplay/UnitController.cs
@@ -1,0 +1,188 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace EmpireOfHonor.Gameplay
+{
+    /// <summary>
+    /// Controls friendly units that can receive orders for movement, holding, or attacking targets.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    [RequireComponent(typeof(Weapon))]
+    [RequireComponent(typeof(Health))]
+    public class UnitController : MonoBehaviour
+    {
+        [SerializeField] private NavMeshAgent agent;
+        [SerializeField] private Weapon weapon;
+        [SerializeField] private Health health;
+        [SerializeField] private float rotationSpeed = 10f;
+        [SerializeField] private float attackChaseBuffer = 0.25f;
+
+        private Vector3 holdPosition;
+        private bool hasHoldPosition;
+        private Health attackTarget;
+
+        private enum UnitState
+        {
+            Idle,
+            Moving,
+            Hold,
+            Attacking
+        }
+
+        private UnitState state = UnitState.Idle;
+
+        private void Awake()
+        {
+            agent ??= GetComponent<NavMeshAgent>();
+            weapon ??= GetComponent<Weapon>();
+            health ??= GetComponent<Health>();
+            holdPosition = transform.position;
+            hasHoldPosition = true;
+        }
+
+        private void Update()
+        {
+            if (!gameObject.activeInHierarchy || health.CurrentHealth <= 0f)
+            {
+                return;
+            }
+
+            switch (state)
+            {
+                case UnitState.Moving:
+                    TickMove();
+                    break;
+                case UnitState.Hold:
+                    TickHold();
+                    break;
+                case UnitState.Attacking:
+                    TickAttack();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Issues a move order towards the specified destination.
+        /// </summary>
+        public void OrderMove(Vector3 destination)
+        {
+            if (!agent.isOnNavMesh)
+            {
+                return;
+            }
+
+            attackTarget = null;
+            hasHoldPosition = true;
+            holdPosition = destination;
+            state = UnitState.Moving;
+            agent.isStopped = false;
+            agent.SetDestination(destination);
+        }
+
+        /// <summary>
+        /// Makes the unit hold its current position.
+        /// </summary>
+        public void OrderHold()
+        {
+            if (!agent.isOnNavMesh)
+            {
+                return;
+            }
+
+            attackTarget = null;
+            hasHoldPosition = true;
+            holdPosition = transform.position;
+            state = UnitState.Hold;
+            agent.isStopped = true;
+        }
+
+        /// <summary>
+        /// Orders the unit to pursue and attack the provided target.
+        /// </summary>
+        public void OrderAttack(Health target)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            attackTarget = target;
+            state = UnitState.Attacking;
+            if (agent.isOnNavMesh)
+            {
+                agent.isStopped = false;
+                agent.SetDestination(target.transform.position);
+            }
+        }
+
+        private void TickMove()
+        {
+            if (!agent.isOnNavMesh)
+            {
+                return;
+            }
+
+            if (!agent.pathPending && agent.remainingDistance <= agent.stoppingDistance)
+            {
+                agent.isStopped = true;
+                state = UnitState.Idle;
+            }
+        }
+
+        private void TickHold()
+        {
+            if (!agent.isOnNavMesh || !hasHoldPosition)
+            {
+                return;
+            }
+
+            var flatPosition = new Vector3(holdPosition.x, transform.position.y, holdPosition.z);
+            transform.position = Vector3.Lerp(transform.position, flatPosition, Time.deltaTime * 2f);
+        }
+
+        private void TickAttack()
+        {
+            if (attackTarget == null || !attackTarget.gameObject.activeInHierarchy || attackTarget.CurrentHealth <= 0f)
+            {
+                state = UnitState.Idle;
+                return;
+            }
+
+            var targetPosition = attackTarget.transform.position;
+            var distance = Vector3.Distance(transform.position, targetPosition);
+            var requiredDistance = weapon.Range + attackChaseBuffer;
+
+            if (agent.isOnNavMesh)
+            {
+                if (distance > requiredDistance)
+                {
+                    agent.isStopped = false;
+                    agent.SetDestination(targetPosition);
+                }
+                else
+                {
+                    agent.isStopped = true;
+                }
+            }
+
+            RotateTowards(targetPosition);
+            if (distance <= weapon.Range + 0.05f)
+            {
+                weapon.TryAttack();
+            }
+        }
+
+        private void RotateTowards(Vector3 targetPosition)
+        {
+            var direction = targetPosition - transform.position;
+            direction.y = 0f;
+            if (direction.sqrMagnitude < 0.001f)
+            {
+                return;
+            }
+
+            var desiredRotation = Quaternion.LookRotation(direction.normalized, Vector3.up);
+            transform.rotation = Quaternion.Slerp(transform.rotation, desiredRotation, rotationSpeed * Time.deltaTime);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/Weapon.cs
+++ b/Assets/Scripts/Gameplay/Weapon.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+
+namespace EmpireOfHonor.Gameplay
+{
+    /// <summary>
+    /// Simple melee weapon that applies damage within a frontal arc with a cooldown.
+    /// </summary>
+    [RequireComponent(typeof(Health))]
+    public class Weapon : MonoBehaviour
+    {
+        [SerializeField] private Transform attackOrigin;
+        [SerializeField] private float damage = 15f;
+        [SerializeField] private float range = 2f;
+        [SerializeField] private float angle = 120f;
+        [SerializeField] private float cooldown = 0.8f;
+        [SerializeField] private LayerMask hitMask = ~0;
+
+        private float nextAttackTime;
+        private Health ownerHealth;
+
+        /// <summary>
+        /// Gets the effective attack range of the weapon.
+        /// </summary>
+        public float Range => range;
+
+        private void Awake()
+        {
+            ownerHealth = GetComponent<Health>();
+            if (attackOrigin == null)
+            {
+                attackOrigin = transform;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to perform an attack if the cooldown has elapsed.
+        /// </summary>
+        public bool TryAttack()
+        {
+            if (Time.time < nextAttackTime)
+            {
+                return false;
+            }
+
+            PerformAttack();
+            nextAttackTime = Time.time + cooldown;
+            return true;
+        }
+
+        private void PerformAttack()
+        {
+            var origin = attackOrigin != null ? attackOrigin.position : transform.position;
+            var forward = attackOrigin != null ? attackOrigin.forward : transform.forward;
+
+            var colliders = Physics.OverlapSphere(origin, range, hitMask, QueryTriggerInteraction.Ignore);
+            foreach (var collider in colliders)
+            {
+                if (collider.attachedRigidbody == null && collider.gameObject == gameObject)
+                {
+                    continue;
+                }
+
+                var health = collider.GetComponentInParent<Health>();
+                if (health == null || health == ownerHealth || health.CurrentHealth <= 0f)
+                {
+                    continue;
+                }
+
+                if (health.TeamId == ownerHealth.TeamId)
+                {
+                    continue;
+                }
+
+                var direction = (health.transform.position - origin).normalized;
+                var currentAngle = Vector3.Angle(forward, direction);
+                if (currentAngle > angle * 0.5f)
+                {
+                    continue;
+                }
+
+                health.ApplyDamage(damage);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Input/CameraSwitcher_Input.cs
+++ b/Assets/Scripts/Input/CameraSwitcher_Input.cs
@@ -1,0 +1,107 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace EmpireOfHonor.Input
+{
+    /// <summary>
+    /// Switches between TPS and tactical cameras and toggles the appropriate action maps.
+    /// </summary>
+    [RequireComponent(typeof(PlayerInput))]
+    public class CameraSwitcher_Input : MonoBehaviour
+    {
+        [SerializeField] private PlayerInput playerInput;
+        [SerializeField] private Camera tpsCamera;
+        [SerializeField] private Camera tacticalCamera;
+        [SerializeField] private TPS_Input tpsController;
+        [SerializeField] private Tactical_Input tacticalController;
+        [SerializeField] private CommandOverlay_Input commandOverlay;
+        [SerializeField] private InputActionReference switchAction;
+
+        private bool tacticalMode;
+
+        private void Awake()
+        {
+            playerInput ??= GetComponent<PlayerInput>();
+        }
+
+        private void OnEnable()
+        {
+            if (switchAction != null)
+            {
+                switchAction.action.Enable();
+                switchAction.action.performed += HandleSwitch;
+            }
+
+            ApplyMode(false);
+        }
+
+        private void OnDisable()
+        {
+            if (switchAction != null)
+            {
+                switchAction.action.performed -= HandleSwitch;
+                switchAction.action.Disable();
+            }
+        }
+
+        private void HandleSwitch(InputAction.CallbackContext context)
+        {
+            if (!context.performed)
+            {
+                return;
+            }
+
+            ApplyMode(!tacticalMode);
+        }
+
+        private void ApplyMode(bool enableTactical)
+        {
+            tacticalMode = enableTactical;
+
+            if (tpsCamera != null)
+            {
+                tpsCamera.gameObject.SetActive(!enableTactical);
+            }
+
+            if (tacticalCamera != null)
+            {
+                tacticalCamera.gameObject.SetActive(enableTactical);
+            }
+
+            if (tpsController != null)
+            {
+                tpsController.enabled = !enableTactical;
+            }
+
+            if (tacticalController != null)
+            {
+                tacticalController.enabled = enableTactical;
+            }
+
+            if (playerInput != null)
+            {
+                var targetMap = enableTactical ? "Tactical" : "Player";
+                if (playerInput.currentActionMap == null || playerInput.currentActionMap.name != targetMap)
+                {
+                    playerInput.SwitchCurrentActionMap(targetMap);
+                }
+            }
+
+            if (commandOverlay != null)
+            {
+                commandOverlay.SetTacticalMode(enableTactical);
+            }
+
+            if (enableTactical)
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+            else
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Input/CommandOverlay_Input.cs
+++ b/Assets/Scripts/Input/CommandOverlay_Input.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.AI;
+using EmpireOfHonor.Gameplay;
+
+namespace EmpireOfHonor.Input
+{
+    /// <summary>
+    /// Issues tactical orders to unit groups based on player input.
+    /// </summary>
+    public class CommandOverlay_Input : MonoBehaviour
+    {
+        [Serializable]
+        private class UnitGroup
+        {
+            public string name;
+            public List<UnitController> units = new();
+        }
+
+        [SerializeField] private Camera tacticalCamera;
+        [SerializeField] private LayerMask groundMask = ~0;
+        [SerializeField] private float navMeshSampleDistance = 5f;
+        [SerializeField] private UnitGroup[] groups = new UnitGroup[4];
+
+        [Header("Input Actions")]
+        [SerializeField] private InputActionReference commandAction;
+        [SerializeField] private InputActionReference holdAction;
+        [SerializeField] private InputActionReference modifierAltAction;
+        [SerializeField] private InputActionReference selectGroup1Action;
+        [SerializeField] private InputActionReference selectGroup2Action;
+        [SerializeField] private InputActionReference selectGroup3Action;
+        [SerializeField] private InputActionReference selectGroup4Action;
+
+        private bool tacticalMode;
+        private int currentGroupIndex;
+
+        private void OnEnable()
+        {
+            EnableAction(commandAction, HandleCommand);
+            EnableAction(holdAction, HandleHold);
+            EnableAction(selectGroup1Action, HandleSelectGroup1);
+            EnableAction(selectGroup2Action, HandleSelectGroup2);
+            EnableAction(selectGroup3Action, HandleSelectGroup3);
+            EnableAction(selectGroup4Action, HandleSelectGroup4);
+
+            if (groups == null || groups.Length == 0)
+            {
+                groups = new UnitGroup[4];
+            }
+        }
+
+        private void OnDisable()
+        {
+            DisableAction(commandAction, HandleCommand);
+            DisableAction(holdAction, HandleHold);
+            DisableAction(selectGroup1Action, HandleSelectGroup1);
+            DisableAction(selectGroup2Action, HandleSelectGroup2);
+            DisableAction(selectGroup3Action, HandleSelectGroup3);
+            DisableAction(selectGroup4Action, HandleSelectGroup4);
+        }
+
+        /// <summary>
+        /// Toggles whether tactical commands should be processed.
+        /// </summary>
+        public void SetTacticalMode(bool value)
+        {
+            tacticalMode = value;
+        }
+
+        private void HandleCommand(InputAction.CallbackContext context)
+        {
+            if (!context.performed || !tacticalMode || !IsModifierActive())
+            {
+                return;
+            }
+
+            if (tacticalCamera == null)
+            {
+                return;
+            }
+
+            var ray = tacticalCamera.ScreenPointToRay(GetPointerPosition());
+            if (!Physics.Raycast(ray, out var hitInfo, 500f, groundMask, QueryTriggerInteraction.Ignore))
+            {
+                return;
+            }
+
+            var targetHealth = hitInfo.collider.GetComponentInParent<Health>();
+            if (targetHealth != null && targetHealth.TeamId == Health.Team.Player)
+            {
+                targetHealth = null;
+            }
+
+            if (targetHealth != null)
+            {
+                IssueAttack(targetHealth);
+            }
+            else
+            {
+                var destination = hitInfo.point;
+                if (NavMesh.SamplePosition(destination, out var navHit, navMeshSampleDistance, NavMesh.AllAreas))
+                {
+                    destination = navHit.position;
+                }
+
+                IssueMove(destination);
+            }
+        }
+
+        private void HandleHold(InputAction.CallbackContext context)
+        {
+            if (!context.performed || !tacticalMode || !IsModifierActive())
+            {
+                return;
+            }
+
+            foreach (var unit in GetCurrentGroup())
+            {
+                unit?.OrderHold();
+            }
+        }
+
+        private void IssueMove(Vector3 destination)
+        {
+            foreach (var unit in GetCurrentGroup())
+            {
+                unit?.OrderMove(destination);
+            }
+        }
+
+        private void IssueAttack(Health target)
+        {
+            foreach (var unit in GetCurrentGroup())
+            {
+                unit?.OrderAttack(target);
+            }
+        }
+
+        private bool IsModifierActive()
+        {
+            return modifierAltAction != null && modifierAltAction.action.IsPressed();
+        }
+
+        private Vector2 GetPointerPosition()
+        {
+            if (Mouse.current != null)
+            {
+                return Mouse.current.position.ReadValue();
+            }
+
+            if (Touchscreen.current != null)
+            {
+                return Touchscreen.current.primaryTouch.position.ReadValue();
+            }
+
+            return new Vector2(Screen.width * 0.5f, Screen.height * 0.5f);
+        }
+
+        private IReadOnlyList<UnitController> GetCurrentGroup()
+        {
+            if (groups == null || groups.Length == 0)
+            {
+                return Array.Empty<UnitController>();
+            }
+
+            if (currentGroupIndex < 0 || currentGroupIndex >= groups.Length || groups[currentGroupIndex] == null)
+            {
+                return Array.Empty<UnitController>();
+            }
+
+            return groups[currentGroupIndex].units;
+        }
+
+        private void SelectGroup(int index)
+        {
+            if (index < 0 || groups == null || index >= groups.Length)
+            {
+                return;
+            }
+
+            currentGroupIndex = index;
+        }
+
+        private void HandleSelectGroup1(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(0);
+            }
+        }
+
+        private void HandleSelectGroup2(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(1);
+            }
+        }
+
+        private void HandleSelectGroup3(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(2);
+            }
+        }
+
+        private void HandleSelectGroup4(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(3);
+            }
+        }
+
+        private void EnableAction(InputActionReference actionReference, Action<InputAction.CallbackContext> handler)
+        {
+            if (actionReference == null || handler == null)
+            {
+                return;
+            }
+
+            actionReference.action.Enable();
+            actionReference.action.performed += handler;
+        }
+
+        private void DisableAction(InputActionReference actionReference, Action<InputAction.CallbackContext> handler)
+        {
+            if (actionReference == null || handler == null)
+            {
+                return;
+            }
+
+            actionReference.action.performed -= handler;
+            actionReference.action.Disable();
+        }
+    }
+}

--- a/Assets/Scripts/Input/TPS_Input.cs
+++ b/Assets/Scripts/Input/TPS_Input.cs
@@ -1,0 +1,189 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using EmpireOfHonor.Gameplay;
+
+namespace EmpireOfHonor.Input
+{
+    /// <summary>
+    /// Handles third-person player input using the Unity Input System.
+    /// </summary>
+    [RequireComponent(typeof(CharacterController))]
+    [RequireComponent(typeof(Weapon))]
+    [RequireComponent(typeof(Health))]
+    public class TPS_Input : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private CharacterController characterController;
+        [SerializeField] private Transform cameraRoot;
+        [SerializeField] private Transform cameraPivot;
+
+        [Header("Movement")]
+        [SerializeField] private float moveSpeed = 4.5f;
+        [SerializeField] private float sprintSpeed = 6.5f;
+        [SerializeField] private float gravity = -9.81f;
+        [SerializeField] private float jumpHeight = 1.5f;
+        [SerializeField] private float rotationSpeed = 12f;
+
+        [Header("Look")]
+        [SerializeField] private float lookSensitivity = 120f;
+        [SerializeField] private float minPitch = -45f;
+        [SerializeField] private float maxPitch = 70f;
+
+        [Header("Input Actions")]
+        [SerializeField] private InputActionReference moveAction;
+        [SerializeField] private InputActionReference lookAction;
+        [SerializeField] private InputActionReference jumpAction;
+        [SerializeField] private InputActionReference sprintAction;
+        [SerializeField] private InputActionReference attackAction;
+
+        private Vector3 velocity;
+        private float pitch;
+        private Weapon weapon;
+
+        private void Awake()
+        {
+            characterController ??= GetComponent<CharacterController>();
+            weapon = GetComponent<Weapon>();
+        }
+
+        private void OnEnable()
+        {
+            EnableAction(moveAction);
+            EnableAction(lookAction);
+            EnableAction(jumpAction);
+            EnableAction(sprintAction);
+            EnableAction(attackAction);
+
+            if (attackAction != null)
+            {
+                attackAction.action.performed += HandleAttack;
+            }
+
+            if (jumpAction != null)
+            {
+                jumpAction.action.performed += HandleJump;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (attackAction != null)
+            {
+                attackAction.action.performed -= HandleAttack;
+            }
+
+            if (jumpAction != null)
+            {
+                jumpAction.action.performed -= HandleJump;
+            }
+
+            DisableAction(moveAction);
+            DisableAction(lookAction);
+            DisableAction(jumpAction);
+            DisableAction(sprintAction);
+            DisableAction(attackAction);
+        }
+
+        private void Update()
+        {
+            HandleLook();
+            HandleMovement();
+        }
+
+        private void HandleMovement()
+        {
+            if (moveAction == null || characterController == null)
+            {
+                return;
+            }
+
+            var moveInput = moveAction.action.ReadValue<Vector2>();
+            var inputVector = new Vector3(moveInput.x, 0f, moveInput.y);
+            var speed = sprintAction != null && sprintAction.action.IsPressed() ? sprintSpeed : moveSpeed;
+
+            if (cameraRoot != null)
+            {
+                var forward = cameraRoot.forward;
+                var right = cameraRoot.right;
+                forward.y = 0f;
+                right.y = 0f;
+                forward.Normalize();
+                right.Normalize();
+                inputVector = forward * moveInput.y + right * moveInput.x;
+            }
+
+            if (inputVector.sqrMagnitude > 1f)
+            {
+                inputVector.Normalize();
+            }
+
+            var desiredVelocity = inputVector * speed;
+            if (characterController.isGrounded && velocity.y < 0f)
+            {
+                velocity.y = -2f;
+            }
+
+            velocity.x = desiredVelocity.x;
+            velocity.z = desiredVelocity.z;
+            velocity.y += gravity * Time.deltaTime;
+
+            characterController.Move(velocity * Time.deltaTime);
+
+            if (inputVector.sqrMagnitude > 0.001f)
+            {
+                var targetRotation = Quaternion.LookRotation(inputVector.normalized, Vector3.up);
+                transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, rotationSpeed * Time.deltaTime);
+            }
+        }
+
+        private void HandleLook()
+        {
+            if (lookAction == null || cameraPivot == null || cameraRoot == null)
+            {
+                return;
+            }
+
+            var lookInput = lookAction.action.ReadValue<Vector2>();
+            var yawDelta = lookInput.x * lookSensitivity * Time.deltaTime;
+            var pitchDelta = lookInput.y * lookSensitivity * Time.deltaTime;
+
+            cameraRoot.Rotate(Vector3.up, yawDelta, Space.World);
+
+            pitch = Mathf.Clamp(pitch - pitchDelta, minPitch, maxPitch);
+            cameraPivot.localRotation = Quaternion.Euler(pitch, 0f, 0f);
+        }
+
+        private void HandleJump(InputAction.CallbackContext context)
+        {
+            if (!context.performed || characterController == null)
+            {
+                return;
+            }
+
+            if (characterController.isGrounded)
+            {
+                velocity.y = Mathf.Sqrt(-2f * gravity * jumpHeight);
+            }
+        }
+
+        private void HandleAttack(InputAction.CallbackContext context)
+        {
+            if (!context.performed || weapon == null)
+            {
+                return;
+            }
+
+            weapon.TryAttack();
+        }
+
+        private static void EnableAction(InputActionReference reference)
+        {
+            reference?.action?.Enable();
+        }
+
+        private static void DisableAction(InputActionReference reference)
+        {
+            reference?.action?.Disable();
+        }
+    }
+}

--- a/Assets/Scripts/Input/Tactical_Input.cs
+++ b/Assets/Scripts/Input/Tactical_Input.cs
@@ -1,0 +1,121 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace EmpireOfHonor.Input
+{
+    /// <summary>
+    /// Handles top-down tactical camera controls using the Unity Input System.
+    /// </summary>
+    public class Tactical_Input : MonoBehaviour
+    {
+        [Header("Movement")]
+        [SerializeField] private float panSpeed = 12f;
+        [SerializeField] private float rotationSpeed = 90f;
+        [SerializeField] private float zoomSpeed = 10f;
+        [SerializeField] private float minHeight = 8f;
+        [SerializeField] private float maxHeight = 40f;
+
+        [Header("Input Actions")]
+        [SerializeField] private InputActionReference panAction;
+        [SerializeField] private InputActionReference rotateLeftAction;
+        [SerializeField] private InputActionReference rotateRightAction;
+        [SerializeField] private InputActionReference zoomAction;
+
+        private Transform cachedTransform;
+
+        private void Awake()
+        {
+            cachedTransform = transform;
+        }
+
+        private void OnEnable()
+        {
+            EnableAction(panAction);
+            EnableAction(rotateLeftAction);
+            EnableAction(rotateRightAction);
+            EnableAction(zoomAction);
+        }
+
+        private void OnDisable()
+        {
+            DisableAction(panAction);
+            DisableAction(rotateLeftAction);
+            DisableAction(rotateRightAction);
+            DisableAction(zoomAction);
+        }
+
+        private void Update()
+        {
+            HandlePan();
+            HandleRotation();
+            HandleZoom();
+        }
+
+        private void HandlePan()
+        {
+            if (panAction == null)
+            {
+                return;
+            }
+
+            var input = panAction.action.ReadValue<Vector2>();
+            var forward = cachedTransform.forward;
+            var right = cachedTransform.right;
+            forward.y = 0f;
+            right.y = 0f;
+            forward.Normalize();
+            right.Normalize();
+
+            var movement = (forward * input.y + right * input.x) * (panSpeed * Time.deltaTime);
+            cachedTransform.position += movement;
+        }
+
+        private void HandleRotation()
+        {
+            float rotation = 0f;
+            if (rotateLeftAction != null && rotateLeftAction.action.IsPressed())
+            {
+                rotation -= 1f;
+            }
+
+            if (rotateRightAction != null && rotateRightAction.action.IsPressed())
+            {
+                rotation += 1f;
+            }
+
+            if (Mathf.Abs(rotation) > 0.01f)
+            {
+                cachedTransform.Rotate(Vector3.up, rotation * rotationSpeed * Time.deltaTime, Space.World);
+            }
+        }
+
+        private void HandleZoom()
+        {
+            if (zoomAction == null)
+            {
+                return;
+            }
+
+            var zoomValue = zoomAction.action.ReadValue<float>();
+            if (Mathf.Abs(zoomValue) < 0.001f)
+            {
+                return;
+            }
+
+            var position = cachedTransform.position;
+            position += cachedTransform.forward * (zoomValue * zoomSpeed * Time.deltaTime);
+            position.y = Mathf.Clamp(position.y, minHeight, maxHeight);
+            cachedTransform.position = position;
+        }
+
+        private static void EnableAction(InputActionReference reference)
+        {
+            reference?.action?.Enable();
+        }
+
+        private static void DisableAction(InputActionReference reference)
+        {
+            reference?.action?.Disable();
+        }
+    }
+}

--- a/Assets/Scripts/UI/SimpleUI.cs
+++ b/Assets/Scripts/UI/SimpleUI.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace EmpireOfHonor.UI
+{
+    /// <summary>
+    /// Populates the UI with control instructions at runtime.
+    /// </summary>
+    [RequireComponent(typeof(Text))]
+    public class SimpleUI : MonoBehaviour
+    {
+        [SerializeField, TextArea] private string customMessage;
+
+        private void Awake()
+        {
+            var textComponent = GetComponent<Text>();
+            if (textComponent == null)
+            {
+                return;
+            }
+
+            textComponent.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            textComponent.alignment = TextAnchor.UpperLeft;
+            textComponent.supportRichText = false;
+            textComponent.horizontalOverflow = HorizontalWrapMode.Wrap;
+            textComponent.verticalOverflow = VerticalWrapMode.Overflow;
+
+            textComponent.text = string.IsNullOrWhiteSpace(customMessage) ? BuildDefaultMessage() : customMessage;
+        }
+
+        private static string BuildDefaultMessage()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("TPS MODE");
+            builder.AppendLine("WASD - Move | Shift - Sprint | Space - Jump | LMB / RT - Attack");
+            builder.AppendLine("C / Select - Switch to Tactical");
+            builder.AppendLine();
+            builder.AppendLine("TACTICAL MODE");
+            builder.AppendLine("WASD / Left Stick - Pan | Q/E - Rotate | Scroll / LT/RT - Zoom");
+            builder.AppendLine("Hold Alt + LMB - Move/Attack | Hold Alt + RMB - Hold Position");
+            builder.AppendLine("1..4 / D-Pad - Select Groups");
+            return builder.ToString();
+        }
+    }
+}

--- a/README_READY_SCENE.md
+++ b/README_READY_SCENE.md
@@ -1,0 +1,14 @@
+# Empire of Honor READY Scene
+
+## Требования
+- Unity 2022.3 LTS
+- Включённый пакет **Input System** (Project Settings → Player → Active Input Handling = *Input System Package (New)*).
+
+## Создание сцены
+1. Откройте проект в Unity.
+2. В меню выберите **Alaia Iva → Create READY Scene (Input System)**.
+3. Дождитесь генерации сцены `Assets/ReadyScene_InputSystem.unity` и откройте её.
+
+## Запуск
+- Нажмите **Play**. Сцена содержит героя, тактическую камеру, союзников и врагов, навмеш и UI-подсказку по управлению.
+- Переключение между TPS и тактическим режимами выполняется клавишей **C** (или кнопкой Select на геймпаде).


### PR DESCRIPTION
## Summary
- add Input System action asset for player and tactical control schemes
- implement TPS, tactical camera, command, and gameplay scripts for the MVP hybrid combat prototype
- provide editor utility to auto-generate a ready-to-play scene with UI instructions

## Testing
- not run (editor scripting only)

------
https://chatgpt.com/codex/tasks/task_e_68da90a07f448324b98955a736226e66