### PR TITLE
Guard input system scripts behind ENABLE_INPUT_SYSTEM

### DIFF
--- a/Assets/Editor/ReadySceneBuilder.cs
+++ b/Assets/Editor/ReadySceneBuilder.cs
@@ -3,17 +3,21 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.InputSystem;
 using UnityEngine.UI;
 using EmpireOfHonor.Gameplay;
 using EmpireOfHonor.Input;
 using EmpireOfHonor.UI;
+
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace EmpireOfHonor.Editor
 {
     /// <summary>
     /// Provides a menu entry to build a ready-to-play scene with required components.
     /// </summary>
+#if ENABLE_INPUT_SYSTEM
     public static class ReadySceneBuilder
     {
         private const string MenuPath = "Alaia Iva/Create READY Scene (Input System)";
@@ -308,5 +312,17 @@ namespace EmpireOfHonor.Editor
             property.enumValueIndex = value;
             property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
         }
+#else
+    public static class ReadySceneBuilder
+    {
+        private const string MenuPath = "Alaia Iva/Create READY Scene (Input System)";
+
+        [MenuItem(MenuPath)]
+        public static void CreateReadyScene()
+        {
+            Debug.LogError(
+                "The READY scene builder requires the Unity Input System package. Please enable it in Project Settings > Player.");
+        }
     }
+#endif
 }

--- a/Assets/Scripts/Input/CameraSwitcher_Input.cs
+++ b/Assets/Scripts/Input/CameraSwitcher_Input.cs
@@ -1,11 +1,15 @@
 using UnityEngine;
+
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
+#endif
 
 namespace EmpireOfHonor.Input
 {
     /// <summary>
     /// Switches between TPS and tactical cameras and toggles the appropriate action maps.
     /// </summary>
+#if ENABLE_INPUT_SYSTEM
     [RequireComponent(typeof(PlayerInput))]
     public class CameraSwitcher_Input : MonoBehaviour
     {
@@ -104,4 +108,52 @@ namespace EmpireOfHonor.Input
             }
         }
     }
+#else
+    public class CameraSwitcher_Input : MonoBehaviour
+    {
+        [SerializeField] private Camera tpsCamera;
+        [SerializeField] private Camera tacticalCamera;
+        [SerializeField] private TPS_Input tpsController;
+        [SerializeField] private Tactical_Input tacticalController;
+        [SerializeField] private CommandOverlay_Input commandOverlay;
+
+        private void Awake()
+        {
+            Debug.LogWarning(
+                "CameraSwitcher_Input requires the Unity Input System package. Please enable it in Project Settings > Player.");
+        }
+
+        private void Start()
+        {
+            // Ensure the tactical overlay still knows about the default mode even without input switching.
+            if (commandOverlay != null)
+            {
+                commandOverlay.SetTacticalMode(false);
+            }
+
+            if (tpsCamera != null)
+            {
+                tpsCamera.gameObject.SetActive(true);
+            }
+
+            if (tacticalCamera != null)
+            {
+                tacticalCamera.gameObject.SetActive(false);
+            }
+
+            if (tpsController != null)
+            {
+                tpsController.enabled = true;
+            }
+
+            if (tacticalController != null)
+            {
+                tacticalController.enabled = false;
+            }
+
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+        }
+    }
+#endif
 }

--- a/Assets/Scripts/Input/CommandOverlay_Input.cs
+++ b/Assets/Scripts/Input/CommandOverlay_Input.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.AI;
 using EmpireOfHonor.Gameplay;
+
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace EmpireOfHonor.Input
 {
@@ -24,6 +27,7 @@ namespace EmpireOfHonor.Input
         [SerializeField] private float navMeshSampleDistance = 5f;
         [SerializeField] private UnitGroup[] groups = new UnitGroup[4];
 
+#if ENABLE_INPUT_SYSTEM
         [Header("Input Actions")]
         [SerializeField] private InputActionReference commandAction;
         [SerializeField] private InputActionReference holdAction;
@@ -32,18 +36,24 @@ namespace EmpireOfHonor.Input
         [SerializeField] private InputActionReference selectGroup2Action;
         [SerializeField] private InputActionReference selectGroup3Action;
         [SerializeField] private InputActionReference selectGroup4Action;
+#endif
 
         private bool tacticalMode;
         private int currentGroupIndex;
 
         private void OnEnable()
         {
+#if ENABLE_INPUT_SYSTEM
             EnableAction(commandAction, HandleCommand);
             EnableAction(holdAction, HandleHold);
             EnableAction(selectGroup1Action, HandleSelectGroup1);
             EnableAction(selectGroup2Action, HandleSelectGroup2);
             EnableAction(selectGroup3Action, HandleSelectGroup3);
             EnableAction(selectGroup4Action, HandleSelectGroup4);
+#else
+            Debug.LogWarning(
+                "CommandOverlay_Input requires the Unity Input System package. Please enable it in Project Settings > Player.");
+#endif
 
             if (groups == null || groups.Length == 0)
             {
@@ -53,12 +63,14 @@ namespace EmpireOfHonor.Input
 
         private void OnDisable()
         {
+#if ENABLE_INPUT_SYSTEM
             DisableAction(commandAction, HandleCommand);
             DisableAction(holdAction, HandleHold);
             DisableAction(selectGroup1Action, HandleSelectGroup1);
             DisableAction(selectGroup2Action, HandleSelectGroup2);
             DisableAction(selectGroup3Action, HandleSelectGroup3);
             DisableAction(selectGroup4Action, HandleSelectGroup4);
+#endif
         }
 
         /// <summary>
@@ -67,6 +79,64 @@ namespace EmpireOfHonor.Input
         public void SetTacticalMode(bool value)
         {
             tacticalMode = value;
+        }
+
+        private IReadOnlyList<UnitController> GetCurrentGroup()
+        {
+            if (groups == null || groups.Length == 0)
+            {
+                return Array.Empty<UnitController>();
+            }
+
+            if (currentGroupIndex < 0 || currentGroupIndex >= groups.Length || groups[currentGroupIndex] == null)
+            {
+                return Array.Empty<UnitController>();
+            }
+
+            return groups[currentGroupIndex].units;
+        }
+
+        private void SelectGroup(int index)
+        {
+            if (index < 0 || groups == null || index >= groups.Length)
+            {
+                return;
+            }
+
+            currentGroupIndex = index;
+        }
+
+#if ENABLE_INPUT_SYSTEM
+        private void HandleSelectGroup1(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(0);
+            }
+        }
+
+        private void HandleSelectGroup2(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(1);
+            }
+        }
+
+        private void HandleSelectGroup3(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(2);
+            }
+        }
+
+        private void HandleSelectGroup4(InputAction.CallbackContext context)
+        {
+            if (context.performed)
+            {
+                SelectGroup(3);
+            }
         }
 
         private void HandleCommand(InputAction.CallbackContext context)
@@ -158,63 +228,6 @@ namespace EmpireOfHonor.Input
             return new Vector2(Screen.width * 0.5f, Screen.height * 0.5f);
         }
 
-        private IReadOnlyList<UnitController> GetCurrentGroup()
-        {
-            if (groups == null || groups.Length == 0)
-            {
-                return Array.Empty<UnitController>();
-            }
-
-            if (currentGroupIndex < 0 || currentGroupIndex >= groups.Length || groups[currentGroupIndex] == null)
-            {
-                return Array.Empty<UnitController>();
-            }
-
-            return groups[currentGroupIndex].units;
-        }
-
-        private void SelectGroup(int index)
-        {
-            if (index < 0 || groups == null || index >= groups.Length)
-            {
-                return;
-            }
-
-            currentGroupIndex = index;
-        }
-
-        private void HandleSelectGroup1(InputAction.CallbackContext context)
-        {
-            if (context.performed)
-            {
-                SelectGroup(0);
-            }
-        }
-
-        private void HandleSelectGroup2(InputAction.CallbackContext context)
-        {
-            if (context.performed)
-            {
-                SelectGroup(1);
-            }
-        }
-
-        private void HandleSelectGroup3(InputAction.CallbackContext context)
-        {
-            if (context.performed)
-            {
-                SelectGroup(2);
-            }
-        }
-
-        private void HandleSelectGroup4(InputAction.CallbackContext context)
-        {
-            if (context.performed)
-            {
-                SelectGroup(3);
-            }
-        }
-
         private void EnableAction(InputActionReference actionReference, Action<InputAction.CallbackContext> handler)
         {
             if (actionReference == null || handler == null)
@@ -236,5 +249,6 @@ namespace EmpireOfHonor.Input
             actionReference.action.performed -= handler;
             actionReference.action.Disable();
         }
+#endif
     }
 }

--- a/Assets/Scripts/Input/TPS_Input.cs
+++ b/Assets/Scripts/Input/TPS_Input.cs
@@ -1,12 +1,16 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 using EmpireOfHonor.Gameplay;
+
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace EmpireOfHonor.Input
 {
     /// <summary>
     /// Handles third-person player input using the Unity Input System.
     /// </summary>
+#if ENABLE_INPUT_SYSTEM
     [RequireComponent(typeof(CharacterController))]
     [RequireComponent(typeof(Weapon))]
     [RequireComponent(typeof(Health))]
@@ -186,4 +190,17 @@ namespace EmpireOfHonor.Input
             reference?.action?.Disable();
         }
     }
+#else
+    [RequireComponent(typeof(CharacterController))]
+    [RequireComponent(typeof(Weapon))]
+    [RequireComponent(typeof(Health))]
+    public class TPS_Input : MonoBehaviour
+    {
+        private void Awake()
+        {
+            Debug.LogWarning(
+                "TPS_Input requires the Unity Input System package. Please enable it in Project Settings > Player.");
+        }
+    }
+#endif
 }

--- a/Assets/Scripts/Input/Tactical_Input.cs
+++ b/Assets/Scripts/Input/Tactical_Input.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
+
+#if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
+#endif
 
 namespace EmpireOfHonor.Input
 {
@@ -15,11 +18,13 @@ namespace EmpireOfHonor.Input
         [SerializeField] private float minHeight = 8f;
         [SerializeField] private float maxHeight = 40f;
 
+#if ENABLE_INPUT_SYSTEM
         [Header("Input Actions")]
         [SerializeField] private InputActionReference panAction;
         [SerializeField] private InputActionReference rotateLeftAction;
         [SerializeField] private InputActionReference rotateRightAction;
         [SerializeField] private InputActionReference zoomAction;
+#endif
 
         private Transform cachedTransform;
 
@@ -30,27 +35,37 @@ namespace EmpireOfHonor.Input
 
         private void OnEnable()
         {
+#if ENABLE_INPUT_SYSTEM
             EnableAction(panAction);
             EnableAction(rotateLeftAction);
             EnableAction(rotateRightAction);
             EnableAction(zoomAction);
+#else
+            Debug.LogWarning(
+                "Tactical_Input requires the Unity Input System package. Please enable it in Project Settings > Player.");
+#endif
         }
 
         private void OnDisable()
         {
+#if ENABLE_INPUT_SYSTEM
             DisableAction(panAction);
             DisableAction(rotateLeftAction);
             DisableAction(rotateRightAction);
             DisableAction(zoomAction);
+#endif
         }
 
         private void Update()
         {
+#if ENABLE_INPUT_SYSTEM
             HandlePan();
             HandleRotation();
             HandleZoom();
+#endif
         }
 
+#if ENABLE_INPUT_SYSTEM
         private void HandlePan()
         {
             if (panAction == null)
@@ -117,5 +132,6 @@ namespace EmpireOfHonor.Input
         {
             reference?.action?.Disable();
         }
+#endif
     }
 }


### PR DESCRIPTION
## Summary
- wrap runtime input scripts with ENABLE_INPUT_SYSTEM guards so they compile when the new Input System package is absent
- provide graceful fallbacks that log guidance when input-driven features cannot be used without the package
- gate the ReadySceneBuilder editor menu behind the same define to avoid missing-type compiler errors

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68daca868ec08324b5bf183855259c57