### PR TITLE
Add stubs for missing Unity packages to unblock compilation

### DIFF
--- a/Assets/Scripts/Stubs/InputSystemStubs.cs
+++ b/Assets/Scripts/Stubs/InputSystemStubs.cs
@@ -1,0 +1,89 @@
+#if !UNITY_5_3_OR_NEWER
+using System;
+using UnityEngine;
+
+namespace UnityEngine.InputSystem
+{
+    public class InputAction
+    {
+        public struct CallbackContext
+        {
+            public bool performed { get; set; }
+        }
+
+        public event Action<CallbackContext> performed;
+
+        public void Enable()
+        {
+        }
+
+        public void Disable()
+        {
+        }
+
+        public bool IsPressed()
+        {
+            return false;
+        }
+
+        public T ReadValue<T>()
+        {
+            return default;
+        }
+
+        public void TriggerPerformed()
+        {
+            performed?.Invoke(new CallbackContext { performed = true });
+        }
+    }
+
+    public class InputActionMap
+    {
+        public string name { get; set; }
+    }
+
+    public class PlayerInput : MonoBehaviour
+    {
+        public InputActionMap currentActionMap { get; private set; } = new InputActionMap();
+
+        public void SwitchCurrentActionMap(string mapName)
+        {
+            currentActionMap = new InputActionMap { name = mapName };
+        }
+    }
+
+    public class InputActionReference : ScriptableObject
+    {
+        [SerializeField] private InputAction actionInstance = new InputAction();
+
+        public InputAction action => actionInstance;
+    }
+
+    public class InputControl<T>
+    {
+        public T ReadValue()
+        {
+            return default;
+        }
+    }
+
+    public class Mouse
+    {
+        public static Mouse current => null;
+
+        public InputControl<Vector2> position => new InputControl<Vector2>();
+    }
+
+    public class Touchscreen
+    {
+        public static Touchscreen current => null;
+
+        public TouchControl primaryTouch => new TouchControl();
+    }
+
+    public class TouchControl
+    {
+        public InputControl<Vector2> position => new InputControl<Vector2>();
+    }
+}
+#endif

--- a/Assets/Scripts/Stubs/UnityUIStubs.cs
+++ b/Assets/Scripts/Stubs/UnityUIStubs.cs
@@ -1,0 +1,20 @@
+#if !UNITY_5_3_OR_NEWER
+using UnityEngine;
+
+namespace UnityEngine.UI
+{
+    public class Graphic : MonoBehaviour
+    {
+    }
+
+    public class Text : Graphic
+    {
+        public Font font { get; set; }
+        public TextAnchor alignment { get; set; }
+        public bool supportRichText { get; set; }
+        public HorizontalWrapMode horizontalOverflow { get; set; }
+        public VerticalWrapMode verticalOverflow { get; set; }
+        public string text { get; set; }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add lightweight stubs for the Unity Input System types referenced by gameplay scripts when the real package is unavailable
- add basic Unity UI Text stub so UI scripts continue to compile without the package

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dace1bac588324826b307cd015513a