### PR TITLE
Guard Input System scripts when package is missing

### DIFF
--- a/Assets/Scripts/Input/CameraSwitcher_Input.cs
+++ b/Assets/Scripts/Input/CameraSwitcher_Input.cs
@@ -1,6 +1,10 @@
 using UnityEngine;
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && UNITY_INPUT_SYSTEM_EXISTS
+#define INPUT_SYSTEM_ENABLED
+#endif
+
+#if INPUT_SYSTEM_ENABLED
 using UnityEngine.InputSystem;
 #endif
 
@@ -9,7 +13,7 @@ namespace EmpireOfHonor.Input
     /// <summary>
     /// Switches between TPS and tactical cameras and toggles the appropriate action maps.
     /// </summary>
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
     [RequireComponent(typeof(PlayerInput))]
     public class CameraSwitcher_Input : MonoBehaviour
     {

--- a/Assets/Scripts/Input/CommandOverlay_Input.cs
+++ b/Assets/Scripts/Input/CommandOverlay_Input.cs
@@ -4,7 +4,11 @@ using UnityEngine;
 using UnityEngine.AI;
 using EmpireOfHonor.Gameplay;
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && UNITY_INPUT_SYSTEM_EXISTS
+#define INPUT_SYSTEM_ENABLED
+#endif
+
+#if INPUT_SYSTEM_ENABLED
 using UnityEngine.InputSystem;
 #endif
 
@@ -27,7 +31,7 @@ namespace EmpireOfHonor.Input
         [SerializeField] private float navMeshSampleDistance = 5f;
         [SerializeField] private UnitGroup[] groups = new UnitGroup[4];
 
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
         [Header("Input Actions")]
         [SerializeField] private InputActionReference commandAction;
         [SerializeField] private InputActionReference holdAction;
@@ -43,7 +47,7 @@ namespace EmpireOfHonor.Input
 
         private void OnEnable()
         {
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
             EnableAction(commandAction, HandleCommand);
             EnableAction(holdAction, HandleHold);
             EnableAction(selectGroup1Action, HandleSelectGroup1);
@@ -63,7 +67,7 @@ namespace EmpireOfHonor.Input
 
         private void OnDisable()
         {
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
             DisableAction(commandAction, HandleCommand);
             DisableAction(holdAction, HandleHold);
             DisableAction(selectGroup1Action, HandleSelectGroup1);
@@ -106,7 +110,7 @@ namespace EmpireOfHonor.Input
             currentGroupIndex = index;
         }
 
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
         private void HandleSelectGroup1(InputAction.CallbackContext context)
         {
             if (context.performed)
@@ -210,9 +214,14 @@ namespace EmpireOfHonor.Input
 
         private bool IsModifierActive()
         {
+#if INPUT_SYSTEM_ENABLED
             return modifierAltAction != null && modifierAltAction.action.IsPressed();
+#else
+            return false;
+#endif
         }
 
+#if INPUT_SYSTEM_ENABLED
         private Vector2 GetPointerPosition()
         {
             if (Mouse.current != null)

--- a/Assets/Scripts/Input/TPS_Input.cs
+++ b/Assets/Scripts/Input/TPS_Input.cs
@@ -1,7 +1,11 @@
 using UnityEngine;
 using EmpireOfHonor.Gameplay;
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && UNITY_INPUT_SYSTEM_EXISTS
+#define INPUT_SYSTEM_ENABLED
+#endif
+
+#if INPUT_SYSTEM_ENABLED
 using UnityEngine.InputSystem;
 #endif
 
@@ -10,7 +14,7 @@ namespace EmpireOfHonor.Input
     /// <summary>
     /// Handles third-person player input using the Unity Input System.
     /// </summary>
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
     [RequireComponent(typeof(CharacterController))]
     [RequireComponent(typeof(Weapon))]
     [RequireComponent(typeof(Health))]

--- a/Assets/Scripts/Input/Tactical_Input.cs
+++ b/Assets/Scripts/Input/Tactical_Input.cs
@@ -1,6 +1,10 @@
 using UnityEngine;
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && UNITY_INPUT_SYSTEM_EXISTS
+#define INPUT_SYSTEM_ENABLED
+#endif
+
+#if INPUT_SYSTEM_ENABLED
 using UnityEngine.InputSystem;
 #endif
 
@@ -18,7 +22,7 @@ namespace EmpireOfHonor.Input
         [SerializeField] private float minHeight = 8f;
         [SerializeField] private float maxHeight = 40f;
 
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
         [Header("Input Actions")]
         [SerializeField] private InputActionReference panAction;
         [SerializeField] private InputActionReference rotateLeftAction;
@@ -35,7 +39,7 @@ namespace EmpireOfHonor.Input
 
         private void OnEnable()
         {
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
             EnableAction(panAction);
             EnableAction(rotateLeftAction);
             EnableAction(rotateRightAction);
@@ -48,7 +52,7 @@ namespace EmpireOfHonor.Input
 
         private void OnDisable()
         {
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
             DisableAction(panAction);
             DisableAction(rotateLeftAction);
             DisableAction(rotateRightAction);
@@ -58,14 +62,14 @@ namespace EmpireOfHonor.Input
 
         private void Update()
         {
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
             HandlePan();
             HandleRotation();
             HandleZoom();
 #endif
         }
 
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
         private void HandlePan()
         {
             if (panAction == null)


### PR DESCRIPTION
## Summary
- wrap all new Input System code paths behind a shared INPUT_SYSTEM_ENABLED define
- fall back to warning-only behaviour when the package is not installed
- keep modifier helpers safe when the Input System types are unavailable

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dad35f92bc8324b6b562a453edb1ea