### PR TITLE
Align ReadySceneBuilder input system guard

### DIFF
--- a/Assets/Editor/ReadySceneBuilder.cs
+++ b/Assets/Editor/ReadySceneBuilder.cs
@@ -8,7 +8,11 @@ using EmpireOfHonor.Gameplay;
 using EmpireOfHonor.Input;
 using EmpireOfHonor.UI;
 
-#if ENABLE_INPUT_SYSTEM
+#if ENABLE_INPUT_SYSTEM && UNITY_INPUT_SYSTEM_EXISTS
+#define INPUT_SYSTEM_ENABLED
+#endif
+
+#if INPUT_SYSTEM_ENABLED
 using UnityEngine.InputSystem;
 #endif
 
@@ -17,7 +21,7 @@ namespace EmpireOfHonor.Editor
     /// <summary>
     /// Provides a menu entry to build a ready-to-play scene with required components.
     /// </summary>
-#if ENABLE_INPUT_SYSTEM
+#if INPUT_SYSTEM_ENABLED
     public static class ReadySceneBuilder
     {
         private const string MenuPath = "Alaia Iva/Create READY Scene (Input System)";


### PR DESCRIPTION
## Summary
- gate the editor ReadySceneBuilder against the same INPUT_SYSTEM_ENABLED symbol used by runtime scripts
- move the Unity Input System using directive behind the new symbol so the editor assembly compiles when the package is absent

## Testing
- not run (Unity editor compilation not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dad65c66ac83248b6b61b71c5afe7e