### PR TITLE
Fix ReadySceneBuilder preprocessor braces

### DIFF
--- a/Assets/Editor/ReadySceneBuilder.cs
+++ b/Assets/Editor/ReadySceneBuilder.cs
@@ -316,6 +316,7 @@ namespace EmpireOfHonor.Editor
             property.enumValueIndex = value;
             property.serializedObject.ApplyModifiedPropertiesWithoutUndo();
         }
+    }
 #else
     public static class ReadySceneBuilder
     {


### PR DESCRIPTION
## Summary
- close the INPUT_SYSTEM_ENABLED ReadySceneBuilder class before the preprocessor fallback block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dadd9dc7c8832497e77e070f28f3ce